### PR TITLE
Close current chat when minimizing to tray

### DIFF
--- a/src-web/injected.js
+++ b/src-web/injected.js
@@ -96,7 +96,7 @@ async function ewSetup() {
 
 void ewSetup();
 
-function closeChat() {
+function ewCloseChat() {
   closeChat.WAKeyboardRun ??= importDefault("WAWebKeyboardRun");
   closeChat.WAKeyboardRun?.('CLOSE_CHAT');
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -149,7 +149,7 @@ function main() {
         console.log(`close ${app.isQuiting}`);
         if (!app.isQuiting) {
           event.preventDefault();
-          mainWindow.webContents.executeJavaScript('closeChat()');
+          mainWindow.webContents.executeJavaScript('ewCloseChat()');
           mainWindow.hide();
           // event.returnValue = false;
         }


### PR DESCRIPTION
Just a small snippet to close the current opened chat when minimizing, this way when you reopen the app you don't read the chat by default.

This is the same behavior on Windows Whatsapp Desktop app.